### PR TITLE
fix the prsentaiton date is out of min-max date range

### DIFF
--- a/lib/src/calendar_week.dart
+++ b/lib/src/calendar_week.dart
@@ -324,7 +324,7 @@ class _CalendarWeekState extends State<CalendarWeek> {
         date: date,
         dateStyle: _compareDate(date, _today)
             ? widget.todayDateStyle
-            : date.weekday == 6 || date.weekday == 7
+            : date != null && (date.weekday== 6 || date.weekday == 7)
                 ? widget.weekendsStyle
                 : widget.dateStyle,
         pressedDateStyle: widget.pressedDateStyle,


### PR DESCRIPTION
if we only want to show 2 weeks range in Calendar Week (e.g:

  minDate: DateTime.now().add(Duration(days: -7),),
  maxDate: DateTime.now().add(Duration(days: 7),),

when scrolling reaching end of range, and date is null, it error.. this is just to fix the exception.