### PR TITLE
Fix stale today highlight when system date changes

### DIFF
--- a/lib/src/calendar_week.dart
+++ b/lib/src/calendar_week.dart
@@ -53,8 +53,7 @@ Example:
               )
 */
 
-  /// Today's date, captured at controller construction time
-  final DateTime today = DateTime.now();
+  DateTime get today => DateTime.now();
 
   bool _hasClient = false;
 


### PR DESCRIPTION
Closes #40

## Problem

`CalendarWeekController.today` was a `final` field set once at construction time:

```dart
final DateTime today = DateTime.now();
```

If the app stayed open across midnight (or the user changed the system clock), `controller.today` remained frozen on the original day. Every `DateItem` used this frozen value to decide which day gets the green background, so the highlight never moved to the real current day.

## Fix

Replace the field with a getter so every rebuild reads the live date:

```dart
DateTime get today => DateTime.now();
```

## Testing

- `flutter analyze` — no issues
- All existing tests pass (`flutter test`)