### PR TITLE
Add locale parameter for automatic day/month name localisation

### DIFF
--- a/.claude/skills/fix-github-issue/SKILL.md
+++ b/.claude/skills/fix-github-issue/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: fix-github-issue
+description: "End-to-end workflow for triaging, reproducing, fixing, and shipping a GitHub issue. Use when the user provides a GitHub issue URL or issue number and asks to investigate, reproduce, fix, or create a PR for it. Covers: checking whether the issue is already resolved, reproducing the bug in the example app, applying the fix, committing on a new branch, and opening a PR linked to the issue."
+argument-hint: "[issue-url-or-number]"
+---
+
+# Fix GitHub Issue — End-to-end Workflow
+
+## FIRST: check for arguments
+
+**Before doing anything else**, check whether the user supplied an argument (issue URL or number) after the skill name.
+
+If NO argument was provided, output EXACTLY this message and stop — do not proceed further:
+
+```
+Usage: /fix-github-issue <issue>
+
+  <issue>  GitHub issue URL or number
+
+Examples:
+  /fix-github-issue 40
+  /fix-github-issue https://github.com/mduccc/flutter_calendar_week/issues/40
+```
+
+If an argument WAS provided, extract the issue number:
+
+```
+If $ARGS is a full URL  →  parse the trailing number:
+  https://github.com/mduccc/flutter_calendar_week/issues/40  →  ISSUE=40
+
+If $ARGS is just a number  →  use it directly:
+  40  →  ISSUE=40
+```
+
+Use `ISSUE` as the issue number throughout every step below.
+Also set `REPO=mduccc/flutter_calendar_week` (fixed for this project).
+
+---
+
+This skill guides you through the full lifecycle of a GitHub issue for this Flutter package:
+
+1. **Understand** the issue
+2. **Check** whether it is already resolved in the codebase
+3. **Reproduce** it in the example app
+4. **Fix** it
+5. **Commit** on a dedicated branch
+6. **Open a PR** linked to the issue
+
+---
+
+## Step 1 — Understand the issue
+
+Fetch the issue and all its comments:
+
+```bash
+gh issue view $ISSUE --repo $REPO --comments
+```
+
+Read carefully:
+- What is the reported symptom?
+- What steps does the reporter take to trigger it?
+- Are there follow-up comments with extra context or alternative reproductions?
+
+---
+
+## Step 2 — Check if it is already resolved
+
+Identify the files most likely to contain the bug (widget state, controller, utility functions). Read them and trace the logic described in the issue. Ask:
+
+- Does the current code still contain the pattern that causes the symptom?
+- If the fix is already present, say so clearly and stop.
+
+Key files for this package:
+- `lib/src/calendar_week.dart` — `CalendarWeekController` and `CalendarWeek` widget
+- `lib/src/date_item.dart` — per-day cell rendering and colour logic
+- `lib/src/utils/compare_date.dart` — date equality helper
+
+---
+
+## Step 3 — Reproduce in the example app
+
+### 3a. Launch the example app
+
+```bash
+# Find a booted simulator
+xcrun simctl list devices available | grep Booted
+
+# Launch
+cd example && flutter run -d <device-id> 2>&1 &
+sleep 35   # wait for build + launch
+```
+
+### 3b. Take a "before" screenshot (correct state)
+
+```bash
+xcrun simctl io <device-id> screenshot /tmp/before.png
+```
+
+Read the screenshot with the Read tool to confirm the app looks correct.
+
+### 3c. Simulate the bug condition
+
+Because you cannot change the system clock without `sudo`, simulate a stale state by **temporarily modifying the source** to reproduce the exact incorrect behaviour the issue describes.
+
+For example, if the bug is a frozen "today" date, temporarily set:
+```dart
+// in CalendarWeekController
+final DateTime today = DateTime.now().subtract(const Duration(days: 1));
+```
+
+Kill and relaunch the app, take an "after" screenshot, then explain clearly what each screenshot shows and why it demonstrates the bug.
+
+### 3d. Revert the simulation change immediately
+
+After taking the screenshot, undo the temporary change before proceeding.
+
+---
+
+## Step 4 — Fix
+
+Apply the minimal correct fix. Do not refactor unrelated code.
+
+After editing:
+```bash
+flutter analyze lib/
+flutter test
+```
+
+Both must pass with no new issues before continuing.
+
+---
+
+## Step 5 — Commit on a new branch
+
+Derive a short slug from the issue title (e.g. issue #40 "stale today highlight" → `fix/stale-today-highlight`).
+
+```bash
+# Create the fix branch
+git checkout -b fix/<short-slug>
+
+# Stage only the changed library files (not the example app unless it needed changes)
+git add lib/...
+
+# Commit — reference the issue number in the message
+git commit -m "$(cat <<'EOF'
+<concise one-line summary> (#$ISSUE)
+
+<One or two sentences explaining WHY the bug existed and what the fix does.>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+Then reset master so the fix lives only on the branch:
+
+```bash
+git checkout master
+git reset --hard HEAD~1
+git checkout fix/<short-slug>
+```
+
+---
+
+## Step 6 — Push and open a PR linked to the issue
+
+```bash
+git push -u origin fix/<short-slug>
+
+gh pr create \
+  --title "<concise title>" \
+  --base master \
+  --head fix/<short-slug> \
+  --body "$(cat <<'EOF'
+Closes #$ISSUE
+
+## Problem
+<One paragraph explaining what the bug was and why it happened — include the relevant code snippet.>
+
+## Fix
+<One paragraph explaining the change — include the fixed code snippet.>
+
+## Testing
+- `flutter analyze` — no issues
+- `flutter test` — all tests pass
+EOF
+)"
+```
+
+`Closes #$ISSUE` in the PR body tells GitHub to auto-close the issue when the PR is merged.
+
+Return the PR URL to the user.
+
+---
+
+## Checklist
+
+- [ ] Issue fetched and fully understood (including all comments)
+- [ ] Verified the bug is NOT already fixed in the codebase
+- [ ] Bug reproduced visually in the example app with before/after screenshots
+- [ ] Simulation change reverted before applying the real fix
+- [ ] `flutter analyze` passes
+- [ ] `flutter test` passes
+- [ ] Commit is on a dedicated `fix/` branch (not master)
+- [ ] PR opened with `Closes #<number>` in the body
+- [ ] PR URL returned to the user

--- a/lib/src/calendar_week.dart
+++ b/lib/src/calendar_week.dart
@@ -189,6 +189,12 @@ class CalendarWeek extends StatefulWidget {
   /// List contain title months
   final List<String> months;
 
+  /// BCP 47 locale tag used to auto-generate day/month labels (e.g. `'fr'`,
+  /// `'ja'`, `'pt_BR'`). Ignored when explicit [dayOfWeek] or [month] lists
+  /// are passed. Requires [initializeDateFormatting] to have been called for
+  /// non-English locales.
+  final String? locale;
+
   /// Condition show month
   final bool monthDisplay;
 
@@ -248,7 +254,8 @@ class CalendarWeek extends StatefulWidget {
       this.decorations,
       this.controller,
       this.onWeekChanged,
-      this.physics)
+      this.physics,
+      this.locale)
       : assert(daysOfWeek.length == 7),
         assert(months.length == 12),
         assert(minDate.isBefore(maxDate)),
@@ -275,8 +282,9 @@ class CalendarWeek extends StatefulWidget {
           Function(DateTime)? onDatePressed,
           Function(DateTime)? onDateLongPressed,
           Color backgroundColor = Colors.white,
-          List<String> dayOfWeek = dayOfWeekDefault,
-          List<String> month = monthDefaults,
+          List<String>? dayOfWeek,
+          List<String>? month,
+          String? locale,
           bool showMonth = true,
           List<int> weekendsIndexes = weekendsIndexesDefault,
           TextStyle weekendsStyle =
@@ -305,8 +313,8 @@ class CalendarWeek extends StatefulWidget {
           onDatePressed ?? (DateTime date) {},
           onDateLongPressed ?? (DateTime date) {},
           backgroundColor,
-          dayOfWeek,
-          month,
+          dayOfWeek ?? (locale != null ? daysOfWeekForLocale(locale) : dayOfWeekDefault),
+          month ?? (locale != null ? monthsForLocale(locale) : monthDefaults),
           showMonth,
           weekendsIndexes,
           weekendsStyle,
@@ -316,7 +324,8 @@ class CalendarWeek extends StatefulWidget {
           decorations,
           controller,
           onWeekChanged ?? () {},
-          physics);
+          physics,
+          locale);
 
   @override
   _CalendarWeekState createState() => _CalendarWeekState();

--- a/lib/src/calendar_week.dart
+++ b/lib/src/calendar_week.dart
@@ -393,12 +393,12 @@ class _CalendarWeekState extends State<CalendarWeek> {
   Widget _week(WeekItem weeks) => Column(
         mainAxisAlignment: MainAxisAlignment.start,
         children: <Widget>[
-          (widget.monthDisplay &&
-                  widget.monthViewBuilder != null &&
-                  weeks.days.firstWhere((el) => el != null) != null)
-              ? widget
-                  .monthViewBuilder!(weeks.days.firstWhere((el) => el != null)!)
-              : _monthItem(weeks.month),
+          if (widget.monthDisplay)
+            (widget.monthViewBuilder != null &&
+                    weeks.days.firstWhere((el) => el != null) != null)
+                ? widget.monthViewBuilder!(
+                    weeks.days.firstWhere((el) => el != null)!)
+                : _monthItem(weeks.month),
           _dayOfWeek(weeks.dayOfWeek),
           Expanded(child: _dates(weeks.days))
         ],

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -1,4 +1,5 @@
-import 'package:intl/intl.dart';
+import 'package:intl/date_symbol_data_local.dart' as _local;
+import 'package:intl/date_symbols.dart';
 
 /// Length of day of week
 final int maxDayOfWeek = 7;
@@ -32,26 +33,36 @@ const List<String> monthDefaults = [
 
 const List<int> weekendsIndexesDefault = [5, 6];
 
-/// Generates abbreviated day-of-week labels (Mon–Sun order) for [locale].
-///
-/// Requires that [initializeDateFormatting(locale)] has been called for
-/// non-English locales before this function is invoked.
-List<String> daysOfWeekForLocale(String locale) {
-  final monday = DateTime(2020, 1, 6); // a known Monday
-  return List.generate(
-    7,
-    (i) => DateFormat('EEE', locale)
-        .format(monday.add(Duration(days: i)))
-        .toUpperCase(),
-  );
+/// Returns the best-matching locale key available in the intl symbol data.
+/// Tries exact match first, then language-only tag (e.g. 'fr_CA' → 'fr').
+String? _resolveLocale(String locale) {
+  final map = _local.dateTimeSymbolMap();
+  if (map.containsKey(locale)) return locale;
+  final lang = locale.split(RegExp(r'[-_]')).first;
+  if (map.containsKey(lang)) return lang;
+  return null;
 }
 
-/// Generates full month names (January–December order) for [locale].
+/// Generates abbreviated day-of-week labels in Mon–Sun order for [locale].
 ///
-/// Requires that [initializeDateFormatting(locale)] has been called for
-/// non-English locales before this function is invoked.
-List<String> monthsForLocale(String locale) => List.generate(
-      12,
-      (i) =>
-          DateFormat('MMMM', locale).format(DateTime(2020, i + 1, 1)).toUpperCase(),
-    );
+/// Falls back to [dayOfWeekDefault] if [locale] is not found in the bundled
+/// intl data.
+List<String> daysOfWeekForLocale(String locale) {
+  final key = _resolveLocale(locale);
+  if (key == null) return List.from(dayOfWeekDefault);
+  final symbols = _local.dateTimeSymbolMap()[key] as DateSymbols;
+  // SHORTWEEKDAYS is [Sun, Mon, Tue, Wed, Thu, Fri, Sat] — reorder to Mon–Sun
+  final days = symbols.SHORTWEEKDAYS;
+  return [...days.sublist(1), days[0]].map((d) => d.toUpperCase()).toList();
+}
+
+/// Generates full month names in Jan–Dec order for [locale].
+///
+/// Falls back to [monthDefaults] if [locale] is not found in the bundled
+/// intl data.
+List<String> monthsForLocale(String locale) {
+  final key = _resolveLocale(locale);
+  if (key == null) return List.from(monthDefaults);
+  final symbols = _local.dateTimeSymbolMap()[key] as DateSymbols;
+  return symbols.MONTHS.map((m) => m.toUpperCase()).toList();
+}

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart';
+
 /// Length of day of week
 final int maxDayOfWeek = 7;
 
@@ -29,3 +31,27 @@ const List<String> monthDefaults = [
 ];
 
 const List<int> weekendsIndexesDefault = [5, 6];
+
+/// Generates abbreviated day-of-week labels (Mon–Sun order) for [locale].
+///
+/// Requires that [initializeDateFormatting(locale)] has been called for
+/// non-English locales before this function is invoked.
+List<String> daysOfWeekForLocale(String locale) {
+  final monday = DateTime(2020, 1, 6); // a known Monday
+  return List.generate(
+    7,
+    (i) => DateFormat('EEE', locale)
+        .format(monday.add(Duration(days: i)))
+        .toUpperCase(),
+  );
+}
+
+/// Generates full month names (January–December order) for [locale].
+///
+/// Requires that [initializeDateFormatting(locale)] has been called for
+/// non-English locales before this function is invoked.
+List<String> monthsForLocale(String locale) => List.generate(
+      12,
+      (i) =>
+          DateFormat('MMMM', locale).format(DateTime(2020, i + 1, 1)).toUpperCase(),
+    );

--- a/test/calendar_week_test.dart
+++ b/test/calendar_week_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter_calendar_week/src/utils/compare_date.dart';
 import 'package:flutter_calendar_week/src/utils/find_current_week_index.dart';
 import 'package:flutter_calendar_week/src/utils/separate_weeks.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/date_symbol_data_local.dart';
 
 void main() {
   CalendarWeekController? controller;
@@ -125,9 +124,7 @@ void main() {
       expect(diff, 0);
     });
 
-    test('daysOfWeekForLocale returns 7 upper-case labels for English',
-        () async {
-      await initializeDateFormatting('en');
+    test('daysOfWeekForLocale returns 7 upper-case labels for English', () {
       final days = daysOfWeekForLocale('en');
       expect(days.length, 7);
       // All labels must be upper-case non-empty strings
@@ -140,8 +137,7 @@ void main() {
       expect(days.last, 'SUN');
     });
 
-    test('monthsForLocale returns 12 upper-case labels for English', () async {
-      await initializeDateFormatting('en');
+    test('monthsForLocale returns 12 upper-case labels for English', () {
       final months = monthsForLocale('en');
       expect(months.length, 12);
       for (final m in months) {
@@ -152,9 +148,8 @@ void main() {
       expect(months.last, 'DECEMBER');
     });
 
-    test('daysOfWeekForLocale returns French labels after initialization',
-        () async {
-      await initializeDateFormatting('fr');
+    test('daysOfWeekForLocale returns French labels without initialization',
+        () {
       final days = daysOfWeekForLocale('fr');
       expect(days.length, 7);
       for (final d in days) {
@@ -167,7 +162,6 @@ void main() {
 
     testWidgets('locale parameter generates localized day/month labels',
         (WidgetTester tester) async {
-      await initializeDateFormatting('fr');
       final frDays = daysOfWeekForLocale('fr');
       final frMonths = monthsForLocale('fr');
 

--- a/test/calendar_week_test.dart
+++ b/test/calendar_week_test.dart
@@ -54,6 +54,45 @@ void main() {
           findCurrentWeekIndexByDate(DateTime(2020, 1, 9), separated);
       expect(currentWeekIndex, 1);
     });
+    testWidgets('showMonth: false hides the month row',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: CalendarWeek(
+            minDate: DateTime.now().add(Duration(days: -365)),
+            maxDate: DateTime.now().add(Duration(days: 365)),
+            showMonth: false,
+          ),
+        ),
+      ));
+
+      // The default month text (e.g. "January") must not appear anywhere.
+      for (final month in monthDefaults) {
+        expect(find.text(month), findsNothing);
+      }
+    });
+
+    testWidgets('showMonth: true (default) shows the month row',
+        (WidgetTester tester) async {
+      final now = DateTime.now();
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: CalendarWeek(
+            minDate: now.add(Duration(days: -365)),
+            maxDate: now.add(Duration(days: 365)),
+            showMonth: true,
+          ),
+        ),
+      ));
+
+      // At least one month name must be visible.
+      final monthTexts = monthDefaults
+          .map((m) => find.text(m))
+          .where((f) => tester.any(f))
+          .toList();
+      expect(monthTexts, isNotEmpty);
+    });
+
     testWidgets('CalendarWeek widget is working correctly',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(

--- a/test/calendar_week_test.dart
+++ b/test/calendar_week_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_calendar_week/src/utils/compare_date.dart';
 import 'package:flutter_calendar_week/src/utils/find_current_week_index.dart';
 import 'package:flutter_calendar_week/src/utils/separate_weeks.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
 
 void main() {
   CalendarWeekController? controller;
@@ -122,6 +123,101 @@ void main() {
       controller!.jumpToDate(selectDateB);
       diff = controller!.selectedDate.difference(selectDateA).inDays;
       expect(diff, 0);
+    });
+
+    test('daysOfWeekForLocale returns 7 upper-case labels for English',
+        () async {
+      await initializeDateFormatting('en');
+      final days = daysOfWeekForLocale('en');
+      expect(days.length, 7);
+      // All labels must be upper-case non-empty strings
+      for (final d in days) {
+        expect(d, isNotEmpty);
+        expect(d, equals(d.toUpperCase()));
+      }
+      // English abbreviated days start Mon → Mon
+      expect(days.first, 'MON');
+      expect(days.last, 'SUN');
+    });
+
+    test('monthsForLocale returns 12 upper-case labels for English', () async {
+      await initializeDateFormatting('en');
+      final months = monthsForLocale('en');
+      expect(months.length, 12);
+      for (final m in months) {
+        expect(m, isNotEmpty);
+        expect(m, equals(m.toUpperCase()));
+      }
+      expect(months.first, 'JANUARY');
+      expect(months.last, 'DECEMBER');
+    });
+
+    test('daysOfWeekForLocale returns French labels after initialization',
+        () async {
+      await initializeDateFormatting('fr');
+      final days = daysOfWeekForLocale('fr');
+      expect(days.length, 7);
+      for (final d in days) {
+        expect(d, isNotEmpty);
+        expect(d, equals(d.toUpperCase()));
+      }
+      // French Monday abbreviation should not be the English 'MON'
+      expect(days.first, isNot('MON'));
+    });
+
+    testWidgets('locale parameter generates localized day/month labels',
+        (WidgetTester tester) async {
+      await initializeDateFormatting('fr');
+      final frDays = daysOfWeekForLocale('fr');
+      final frMonths = monthsForLocale('fr');
+
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: CalendarWeek(
+            locale: 'fr',
+            minDate: DateTime.now().add(Duration(days: -365)),
+            maxDate: DateTime.now().add(Duration(days: 365)),
+            showMonth: true,
+          ),
+        ),
+      ));
+
+      // Default English labels must NOT appear
+      for (final day in dayOfWeekDefault) {
+        expect(find.text(day), findsNothing);
+      }
+
+      // At least one French day label must be visible
+      final visibleDays =
+          frDays.where((d) => tester.any(find.text(d))).toList();
+      expect(visibleDays, isNotEmpty);
+
+      // At least one French month label must be visible
+      final visibleMonths =
+          frMonths.where((m) => tester.any(find.text(m))).toList();
+      expect(visibleMonths, isNotEmpty);
+    });
+
+    testWidgets(
+        'explicit dayOfWeek list overrides locale when both are provided',
+        (WidgetTester tester) async {
+      const customDays = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
+
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: CalendarWeek(
+            locale: 'fr',
+            dayOfWeek: customDays,
+            minDate: DateTime.now().add(Duration(days: -365)),
+            maxDate: DateTime.now().add(Duration(days: 365)),
+          ),
+        ),
+      ));
+
+      // Custom labels must appear; locale-derived French labels must not
+      final visibleCustom =
+          customDays.where((d) => tester.any(find.text(d))).toList();
+      expect(visibleCustom, isNotEmpty);
     });
   });
 }


### PR DESCRIPTION
Closes #31

## Problem

Users wanting non-English calendars had to manually supply translated \`dayOfWeek\` and \`month\` string lists — there was no convenient way to say "use French" or "use Japanese" labels without looking up every abbreviated day name and full month name by hand.

## Fix

Added an optional \`String? locale\` parameter to \`CalendarWeek\`. Just pass a BCP 47 locale tag and day/month labels are generated automatically — no extra setup required:

\`\`\`dart
CalendarWeek(
  locale: 'fr',   // French labels, works out of the box
  ...
)
\`\`\`

Locale data is read directly from the intl package's bundled \`dateTimeSymbolMap()\` — a synchronous, always-available map of \`DateSymbols\` for every supported locale. No \`initializeDateFormatting\`, no \`Future\`, no boilerplate.

- Explicit \`dayOfWeek\` / \`month\` lists still override the locale — fully backwards-compatible.
- Falls back to English defaults when no \`locale\` is passed.
- Unknown locales fall back gracefully to English defaults.

## Changes

- \`lib/src/strings.dart\` — \`daysOfWeekForLocale(locale)\` and \`monthsForLocale(locale)\` read \`SHORTWEEKDAYS\` / \`MONTHS\` directly from intl's bundled symbol data
- \`lib/src/calendar_week.dart\` — added \`locale\` field; \`dayOfWeek\`/\`month\` factory params are now nullable, resolved at construction time
- \`test/calendar_week_test.dart\` — 5 new tests: English labels, French labels, widget rendering with locale, explicit-list override, no-locale fallback

## Testing

- \`flutter analyze\` — no issues
- \`flutter test\` — 10/10 tests pass