### PR TITLE
Release 4.1.0 — locale parameter & showMonth fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.1.0]
+ - Add `locale` parameter to `CalendarWeek` for automatic day/month name localisation
+ - Fix `showMonth` parameter not hiding month row
+ - Fix locale helpers to use built-in intl symbol data
+ - Add unit tests for `showMonth` parameter
+
 ## [4.0.1]
  - Update metadata
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -155,6 +155,7 @@ class _CalendarHeader extends StatelessWidget {
         child: Stack(
           children: [
             CalendarWeek(
+              locale: 'en',
               controller: controller,
               height: 110,
               showMonth: true,

--- a/lib/src/calendar_week.dart
+++ b/lib/src/calendar_week.dart
@@ -190,8 +190,7 @@ class CalendarWeek extends StatefulWidget {
 
   /// BCP 47 locale tag used to auto-generate day/month labels (e.g. `'fr'`,
   /// `'ja'`, `'pt_BR'`). Ignored when explicit [dayOfWeek] or [month] lists
-  /// are passed. Requires [initializeDateFormatting] to have been called for
-  /// non-English locales.
+  /// are passed.
   final String? locale;
 
   /// Condition show month

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_calendar_week
 description: Flutter calendar week UI package
-version: 4.0.1
+version: 4.1.0
 repository: https://github.com/mduccc/flutter_calendar_week
 
 environment:


### PR DESCRIPTION
## Summary

- Add `locale` parameter to `CalendarWeek` for automatic day/month name localisation
- Fix `showMonth` parameter not hiding the month row
- Fix locale helpers to use built-in intl symbol data (no `initializeDateFormatting` required)
- Add unit tests for `showMonth` parameter

## Test plan

- [x] Run `flutter test` — all tests pass
- [x] Verify locale parameter produces correct day/month names for non-English locales (e.g. `'fr'`, `'ja'`)
- [x] Verify `showMonth: false` hides the month row

🤖 Generated with [Claude Code](https://claude.com/claude-code)